### PR TITLE
Improve cross-platform support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set default behavior to automatically normalize line endings to CRLF on checkout
+* text=auto eol=crlf

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -2,6 +2,18 @@ const fs = require('fs');
 const path = require('path');
 
 // helper functions
+
+// reads a file with line endings normalized to LF (\n)
+function readFileNormalized(filePath) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    return content.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+// converts LF line endings to CRLF
+function convertToCRLF(content) {
+    return content.replace(/\n/g, '\r\n');
+}
+
 // gets n number of tabs
 function getTabs(count, tab = '    ') {
     return Array(count).fill(tab).join('');
@@ -160,11 +172,11 @@ function collectScripts(dirName) {
         // the script has css
         const hasStyles = fs.existsSync(cssPath);
         // get the css
-        const css = hasStyles ? fs.readFileSync(cssPath, 'utf8') : null;
+        const css = hasStyles ? readFileNormalized(cssPath) : null;
         const {
             fn,
             includes
-        } = getJS(fs.readFileSync(jsPath, 'utf8'));
+        } = getJS(readFileNormalized(jsPath));
         
         return {
             fn,
@@ -187,8 +199,8 @@ function collectScripts(dirName) {
 }
 
 module.exports = function builder(srcDirectory) {
-    const meta = fs.readFileSync(path.join(srcDirectory, 'meta.js'), 'utf8');
-    const deps = fs.readFileSync(path.join(srcDirectory, 'deps.js'), 'utf8');
+    const meta = readFileNormalized(path.join(srcDirectory, 'meta.js'));
+    const deps = readFileNormalized(path.join(srcDirectory, 'deps.js'));
     const scripts = collectScripts(srcDirectory);
     const code = scripts
         // get the function from the script
@@ -308,8 +320,12 @@ module.exports = function builder(srcDirectory) {
         scriptsStr
     ].join('\n\n');
     
+    // Convert the final output to CRLF line endings
+    const outputWithCRLF = convertToCRLF(outputStr);
+    const metaWithCRLF = convertToCRLF(metaStr);
+    
     return {
-        script: outputStr,
-        meta: metaStr
+        script: outputWithCRLF,
+        meta: metaWithCRLF
     };
-}
+};

--- a/lib/getPaths.js
+++ b/lib/getPaths.js
@@ -5,10 +5,8 @@ function getPath(filename) {
     const makeAbsolutePath = (filename) => {
         return path.join(workingDirectory, filename.replace(/^\.\//, ''));
     };
-    const isAbsolutePath = /^[\/\\]/.test(filename);
     
-    if (isAbsolutePath) {
-        // path is already absolute
+    if (path.isAbsolute(filename)) {
         return filename;
     }
     
@@ -17,7 +15,7 @@ function getPath(filename) {
 
 module.exports = function({src, output}) {
     return {
-        srcDir: getPath(src).replace(/\/$/, '') + '/src',
+        srcDir: path.join(getPath(src), 'src'),
         outputPath: getPath(output)
     };
 };


### PR DESCRIPTION
Adds the following changes so that packus can run properly on OSes other than Linux:
- Configure Git to use CRLF line endings via .gitattributes
- Normalize file reading to LF internally, then output final files (.user.js, .meta.js) with CRLF line endings
- Use Node.js path utilities instead of a regex which doesn't work on a Windows path.